### PR TITLE
Bugfix alias path context not found

### DIFF
--- a/src/main/java/org/mycore/alias/servlets/MCRAliasContentServlet.java
+++ b/src/main/java/org/mycore/alias/servlets/MCRAliasContentServlet.java
@@ -241,7 +241,7 @@ public class MCRAliasContentServlet extends MCRContentServlet {
                             aliasPathContext = aliasPathContext
                                     .replaceFirst((String) relatedDocument.getFieldValue(ALIAS), "");
 
-                            LOGGER.info("Process Alias Context: Remove " + currentAlias + " from current aliasPathContext - New Alias Path Context is [" + aliasPathContext + "]");
+                            LOGGER.info("Process Alias Path Context: Remove " + currentAlias + " from current aliasPathContext - New Alias Path Context is [" + aliasPathContext + "]");
                             
                             return getContentFromAliasPath(aliasPathContext, fullPath,
                                     (String) relatedDocument.getFieldValue(OBJECT_ID), request, response);

--- a/src/main/java/org/mycore/alias/servlets/MCRAliasContentServlet.java
+++ b/src/main/java/org/mycore/alias/servlets/MCRAliasContentServlet.java
@@ -233,11 +233,16 @@ public class MCRAliasContentServlet extends MCRContentServlet {
 
                         String currentAlias = (String) relatedDocument.getFieldValue(ALIAS);
 
-                        if (currentAlias != null && aliasPathContext.startsWith(currentAlias)) {
+                        if (currentAlias != null && aliasPathContext.toLowerCase().startsWith(currentAlias.toLowerCase())) {
 
+                            LOGGER.info("Process Alias Path Context: Alias Path Context " + aliasPathContext
+                                + " found in Document " + (String) relatedDocument.getFieldValue(OBJECT_ID));
+                            
                             aliasPathContext = aliasPathContext
                                     .replaceFirst((String) relatedDocument.getFieldValue(ALIAS), "");
 
+                            LOGGER.info("Process Alias Context: Remove " + currentAlias + " from current aliasPathContext - New Alias Path Context is [" + aliasPathContext + "]");
+                            
                             return getContentFromAliasPath(aliasPathContext, fullPath,
                                     (String) relatedDocument.getFieldValue(OBJECT_ID), request, response);
                         }

--- a/src/main/java/org/mycore/alias/servlets/MCRAliasContentServlet.java
+++ b/src/main/java/org/mycore/alias/servlets/MCRAliasContentServlet.java
@@ -229,31 +229,38 @@ public class MCRAliasContentServlet extends MCRContentServlet {
 
                 try {
                     SolrDocumentList relatedDocuments = resolveSolrDocuments(searchStr);
-
+                    
+                    String nextAliasPathContextAfter = aliasPathContext;
+                    String relatedObjectId = null;
+                    
                     for (SolrDocument relatedDocument : relatedDocuments) {
 
                         String currentAliasOrig = (String) relatedDocument.getFieldValue(ALIAS);
-                        
+
                         if (currentAliasOrig != null) {
                             String currentAlias = currentAliasOrig.toLowerCase();
                             String possibleAliasPathContextAfter = aliasPathContext.replaceFirst(currentAlias, "");
                             
-                            if (aliasPathContext.startsWith(currentAlias) && 
-                                (possibleAliasPathContextAfter.startsWith("/") || possibleAliasPathContextAfter.trim().isEmpty())) {
-    
-                                LOGGER.debug("Process Alias Path Context: Alias Path Context " + aliasPathContext
-                                    + " found in Document " + (String) relatedDocument.getFieldValue(OBJECT_ID));
-                                
-                                aliasPathContext = possibleAliasPathContextAfter;
-    
-                                LOGGER.debug("Process Alias Path Context: Remove " + currentAlias + " from current aliasPathContext - New Alias Path Context is [" + aliasPathContext + "]");
-    
-                                return getContentFromAliasPath(aliasPathContext, fullPath,
-                                        (String) relatedDocument.getFieldValue(OBJECT_ID), request, response);
+                            if (nextAliasPathContextAfter.length() > possibleAliasPathContextAfter.length()) {
+                                nextAliasPathContextAfter = possibleAliasPathContextAfter;
+                                relatedObjectId = (String) relatedDocument.getFieldValue(OBJECT_ID);
                             }
                         }
                     }
+                    
+                    if (relatedObjectId != null) {
 
+                        LOGGER.debug("Process Alias Path Context: Alias Path Context " + aliasPathContext
+                            + " found in Document " + relatedObjectId);
+                        
+                        aliasPathContext = nextAliasPathContextAfter;
+
+                        LOGGER.debug("Process Alias Path Context:  New Alias Path Context is [" + aliasPathContext + "]");
+
+                        return getContentFromAliasPath(aliasPathContext, fullPath, relatedObjectId, request, response);
+                    }
+                    
+                    
                     if (relatedDocuments.getNumFound() == 0) {
                         LOGGER.debug("Process Alias Path Context: No Documents found with searchStr: [" + searchStr + "]");
                     } else {

--- a/src/main/java/org/mycore/alias/servlets/MCRAliasContentServlet.java
+++ b/src/main/java/org/mycore/alias/servlets/MCRAliasContentServlet.java
@@ -228,7 +228,7 @@ public class MCRAliasContentServlet extends MCRContentServlet {
 
                 try {
                     SolrDocumentList relatedDocuments = resolveSolrDocuments(searchStr);
-
+                    
                     for (SolrDocument relatedDocument : relatedDocuments) {
 
                         String currentAlias = (String) relatedDocument.getFieldValue(ALIAS);
@@ -247,6 +247,15 @@ public class MCRAliasContentServlet extends MCRContentServlet {
                                     (String) relatedDocument.getFieldValue(OBJECT_ID), request, response);
                         }
                     }
+                    
+                    if (relatedDocuments.getNumFound() == 0) {
+                        LOGGER.info("Process Alias Path Context: No Documents found with searchStr: [" + searchStr + "]");
+                    } else {
+                        LOGGER.info("Process Alias Path Context: Solr query [" + searchStr + "] has got "
+                            + relatedDocuments.getNumFound()
+                            + " documents, but these documents does not include aliasPathContext " + aliasPathContext);
+                    }
+                    
                 } catch (SolrServerException | IOException e) {
                     LOGGER.error("Error in communication with solr server: " + e.getMessage());
                 }

--- a/src/main/java/org/mycore/alias/servlets/MCRAliasContentServlet.java
+++ b/src/main/java/org/mycore/alias/servlets/MCRAliasContentServlet.java
@@ -236,13 +236,15 @@ public class MCRAliasContentServlet extends MCRContentServlet {
                         
                         if (currentAliasOrig != null) {
                             String currentAlias = currentAliasOrig.toLowerCase();
-    
-                            if (aliasPathContext.startsWith(currentAlias)) {
+                            String possibleAliasPathContextAfter = aliasPathContext.replaceFirst(currentAlias, "");
+                            
+                            if (aliasPathContext.startsWith(currentAlias) && 
+                                (possibleAliasPathContextAfter.startsWith("/") || possibleAliasPathContextAfter.trim().isEmpty())) {
     
                                 LOGGER.debug("Process Alias Path Context: Alias Path Context " + aliasPathContext
                                     + " found in Document " + (String) relatedDocument.getFieldValue(OBJECT_ID));
                                 
-                                aliasPathContext = aliasPathContext.replaceFirst(currentAlias, "");
+                                aliasPathContext = possibleAliasPathContextAfter;
     
                                 LOGGER.debug("Process Alias Path Context: Remove " + currentAlias + " from current aliasPathContext - New Alias Path Context is [" + aliasPathContext + "]");
     

--- a/src/main/java/org/mycore/alias/servlets/MCRAliasContentServlet.java
+++ b/src/main/java/org/mycore/alias/servlets/MCRAliasContentServlet.java
@@ -233,6 +233,8 @@ public class MCRAliasContentServlet extends MCRContentServlet {
                     String nextAliasPathContextAfter = aliasPathContext;
                     String relatedObjectId = null;
                     
+                    LOGGER.debug("Process Alias Path Context: Try to shrink Alias Path Context " + aliasPathContext);
+                    
                     for (SolrDocument relatedDocument : relatedDocuments) {
 
                         String currentAliasOrig = (String) relatedDocument.getFieldValue(ALIAS);
@@ -242,8 +244,10 @@ public class MCRAliasContentServlet extends MCRContentServlet {
                             String possibleAliasPathContextAfter = aliasPathContext.replaceFirst(currentAlias, "");
                             
                             if (nextAliasPathContextAfter.length() > possibleAliasPathContextAfter.length()) {
-                                nextAliasPathContextAfter = possibleAliasPathContextAfter;
+                                nextAliasPathContextAfter = possibleAliasPathContextAfter;       
                                 relatedObjectId = (String) relatedDocument.getFieldValue(OBJECT_ID);
+                                
+                                LOGGER.debug("---- Process Alias Path Context: " + currentAlias + " found in " + aliasPathContext + ". Shrink aliasPathContext into " + nextAliasPathContextAfter);
                             }
                         }
                     }


### PR DESCRIPTION
Problems with alike alias parts fixed.

Examples for alias parts which previously caused problems:
../janz_weltkrieg_tuerkisch -> not found
../janz_weltkrieg -> found

../winter_history/1  -> not found
../winter_history -> found



